### PR TITLE
Updated to latest API version - added LicenceKey parameter

### DIFF
--- a/apiclient_pkg/Client.go
+++ b/apiclient_pkg/Client.go
@@ -43,7 +43,7 @@ func (me *APICLIENT_IMPL) IdentityCheck(
 
 	//prepare headers for the outgoing request
 	headers := map[string]interface{}{
-		"user-agent":   "Threema/2.8",
+		"user-agent":   "Threema/4.33A",
 		"accept":       "application/json",
 		"content-type": "application/json; charset=utf-8",
 	}
@@ -101,7 +101,7 @@ func (me *APICLIENT_IMPL) IdentityMatch(
 
 	//prepare headers for the outgoing request
 	headers := map[string]interface{}{
-		"user-agent":   "Threema/2.8",
+		"user-agent":   "Threema/4.33A",
 		"accept":       "application/json",
 		"content-type": "application/json; charset=utf-8",
 	}
@@ -159,7 +159,7 @@ func (me *APICLIENT_IMPL) IdentityLinkEmail(
 
 	//prepare headers for the outgoing request
 	headers := map[string]interface{}{
-		"user-agent":   "Threema/2.8",
+		"user-agent":   "Threema/4.33A",
 		"accept":       "application/json",
 		"content-type": "application/json; charset=utf-8",
 	}
@@ -217,7 +217,7 @@ func (me *APICLIENT_IMPL) IdentityCheckRevocationKey(
 
 	//prepare headers for the outgoing request
 	headers := map[string]interface{}{
-		"user-agent":   "Threema/2.8",
+		"user-agent":   "Threema/4.33A",
 		"accept":       "application/json",
 		"content-type": "application/json; charset=utf-8",
 	}
@@ -275,7 +275,7 @@ func (me *APICLIENT_IMPL) IdentityCheckRevocationKeyStage2(
 
 	//prepare headers for the outgoing request
 	headers := map[string]interface{}{
-		"user-agent":   "Threema/2.8",
+		"user-agent":   "Threema/4.33A",
 		"accept":       "application/json",
 		"content-type": "application/json; charset=utf-8",
 	}
@@ -333,7 +333,7 @@ func (me *APICLIENT_IMPL) IdentityLinkEmailStage2(
 
 	//prepare headers for the outgoing request
 	headers := map[string]interface{}{
-		"user-agent":   "Threema/2.8",
+		"user-agent":   "Threema/4.33A",
 		"accept":       "application/json",
 		"content-type": "application/json; charset=utf-8",
 	}
@@ -391,7 +391,7 @@ func (me *APICLIENT_IMPL) IdentityCreate(
 
 	//prepare headers for the outgoing request
 	headers := map[string]interface{}{
-		"user-agent":   "Threema/2.8",
+		"user-agent":   "Threema/4.33A",
 		"accept":       "application/json",
 		"content-type": "application/json; charset=utf-8",
 	}
@@ -449,7 +449,7 @@ func (me *APICLIENT_IMPL) IdentityCreateStage2(
 
 	//prepare headers for the outgoing request
 	headers := map[string]interface{}{
-		"user-agent":   "Threema/2.8",
+		"user-agent":   "Threema/4.33A",
 		"accept":       "application/json",
 		"content-type": "application/json; charset=utf-8",
 	}
@@ -507,7 +507,7 @@ func (me *APICLIENT_IMPL) IdentitySetFeaturelevel(
 
 	//prepare headers for the outgoing request
 	headers := map[string]interface{}{
-		"user-agent":   "Threema/2.8",
+		"user-agent":   "Threema/4.33A",
 		"accept":       "application/json",
 		"content-type": "application/json; charset=utf-8",
 	}
@@ -565,7 +565,7 @@ func (me *APICLIENT_IMPL) IdentitySetFeaturelevelStage2(
 
 	//prepare headers for the outgoing request
 	headers := map[string]interface{}{
-		"user-agent":   "Threema/2.8",
+		"user-agent":   "Threema/4.33A",
 		"accept":       "application/json",
 		"content-type": "application/json; charset=utf-8",
 	}
@@ -623,7 +623,7 @@ func (me *APICLIENT_IMPL) IdentityMatchStage2(
 
 	//prepare headers for the outgoing request
 	headers := map[string]interface{}{
-		"user-agent":   "Threema/2.8",
+		"user-agent":   "Threema/4.33A",
 		"accept":       "application/json",
 		"content-type": "application/json; charset=utf-8",
 	}
@@ -690,7 +690,7 @@ func (me *APICLIENT_IMPL) IdentityById(
 
 	//prepare headers for the outgoing request
 	headers := map[string]interface{}{
-		"user-agent": "Threema/2.8",
+		"user-agent": "Threema/4.33A",
 		"accept":     "application/json",
 	}
 
@@ -747,7 +747,7 @@ func (me *APICLIENT_IMPL) IdentitySetRevocationKey(
 
 	//prepare headers for the outgoing request
 	headers := map[string]interface{}{
-		"user-agent":   "Threema/2.8",
+		"user-agent":   "Threema/4.33A",
 		"accept":       "application/json",
 		"content-type": "application/json; charset=utf-8",
 	}
@@ -805,7 +805,7 @@ func (me *APICLIENT_IMPL) IdentitySetRevocationKeyStage2(
 
 	//prepare headers for the outgoing request
 	headers := map[string]interface{}{
-		"user-agent":   "Threema/2.8",
+		"user-agent":   "Threema/4.33A",
 		"accept":       "application/json",
 		"content-type": "application/json; charset=utf-8",
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,1 @@
+module github.com/o3ma/o3rest

--- a/models_pkg/Models.go
+++ b/models_pkg/Models.go
@@ -127,6 +127,8 @@ type CreateStage2Request struct {
     PublicKey       *string         `json:"publicKey,omitempty" form:"publicKey,omitempty"` //TODO: Write general description for this field
     Response        *string         `json:"response,omitempty" form:"response,omitempty"` //TODO: Write general description for this field
     Token           *string         `json:"token,omitempty" form:"token,omitempty"` //TODO: Write general description for this field
+    DeviceId        *string         `json:"deviceId,omitempty" form:"deviceId,omitempty"`
+    LicenseKey      *string         `json:"licenseKey,omitempty" form:"licenseKey,omitempty"`
 }
 
 /*


### PR DESCRIPTION
As the current version of the API is not supported the creation of a NEW identity is not possible anymore. The following error is the result: https://github.com/o3ma/o3rest/issues/2

Using the updated API and a license from the theema store (shop.threema.ch) it works again.

Also see: https://github.com/o3ma/o3/pull/29